### PR TITLE
Change rotation direction to match core output

### DIFF
--- a/releases/Planet Probe (Not Working).mra
+++ b/releases/Planet Probe (Not Working).mra
@@ -18,7 +18,7 @@
 	<about></about>
 
 	<resolution>15kHz</resolution>
-	<rotation>vertical (cw)</rotation>
+	<rotation>vertical (ccw)</rotation>
 	<flip>no</flip>
 
 	<players>2 (alternating)</players>


### PR DESCRIPTION
The Direct Video info frame uses the <rotation> string to communicate rotation direction. 

Even though mame lists this as a CW game, the core outputs CCW, so the MRA should reflect that.